### PR TITLE
Rate-limit order submission and add real-time new-order alert

### DIFF
--- a/src/components/NewOrderFlash.tsx
+++ b/src/components/NewOrderFlash.tsx
@@ -1,0 +1,33 @@
+import { useEffect } from 'react';
+
+export interface FlashOrder {
+  orderId: string;
+  table?: string;
+  total: number;
+}
+
+interface NewOrderFlashProps {
+  order: FlashOrder | null;
+  onDismiss: () => void;
+}
+
+export const NewOrderFlash = ({ order, onDismiss }: NewOrderFlashProps) => {
+  useEffect(() => {
+    if (!order) return;
+    const timeout = setTimeout(onDismiss, 4500);
+    return () => clearTimeout(timeout);
+  }, [order, onDismiss]);
+
+  if (!order) return null;
+
+  return (
+    <div className="fixed inset-0 z-[100] pointer-events-none flex items-center justify-center bg-amber-500/30 animate-pulse">
+      <div className="bg-turbo-dark/90 border-2 border-amber-400 rounded-xl px-8 py-6 text-center shadow-2xl">
+        <p className="text-3xl font-bold text-amber-400">🔔 New Order</p>
+        <p className="text-lg text-turbo-text mt-2">
+          Table {order.table ?? '—'} · {order.total} Lei
+        </p>
+      </div>
+    </div>
+  );
+};

--- a/src/components/NewOrderFlash.tsx
+++ b/src/components/NewOrderFlash.tsx
@@ -21,7 +21,7 @@ export const NewOrderFlash = ({ order, onDismiss }: NewOrderFlashProps) => {
   if (!order) return null;
 
   return (
-    <div className="fixed inset-0 z-[100] pointer-events-none flex items-center justify-center bg-amber-500/30 animate-pulse">
+    <div className="fixed inset-0 z-40 pointer-events-none flex items-center justify-center bg-amber-500/30 animate-pulse">
       <div className="bg-turbo-dark/90 border-2 border-amber-400 rounded-xl px-8 py-6 text-center shadow-2xl">
         <p className="text-3xl font-bold text-amber-400">🔔 New Order</p>
         <p className="text-lg text-turbo-text mt-2">

--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useCallback } from 'react';
 import { Bell, MoreHorizontal, RefreshCw, Filter, Clock, CheckCircle, Package, Sparkles, List, History, Volume2 } from 'lucide-react';
 import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
@@ -29,6 +29,7 @@ const Admin = () => {
   const knownOrderIds = useRef<Set<string> | null>(null);
   const audioCtxRef = useRef<AudioContext | null>(null);
   const [flashOrder, setFlashOrder] = useState<FlashOrder | null>(null);
+  const dismissFlash = useCallback(() => setFlashOrder(null), []);
 
   const ensureAudioCtx = () => {
     if (!audioCtxRef.current) {
@@ -185,7 +186,7 @@ const Admin = () => {
 
   return (
     <div className="min-h-screen bg-turbo-dark text-turbo-text pb-20">
-      <NewOrderFlash order={flashOrder} onDismiss={() => setFlashOrder(null)} />
+      <NewOrderFlash order={flashOrder} onDismiss={dismissFlash} />
       <header className="flex items-center justify-between p-4 border-b border-border">
         <NavigationSidebar />
 

--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -14,6 +14,7 @@ import {
   getAdminOrders,
   getAdminNotifications,
   updateOrderStatus,
+  subscribeToAdminOrders,
   OrderDetails
 } from '@/services/orderService';
 import { toast } from '@/hooks/use-toast';
@@ -152,7 +153,6 @@ const Admin = () => {
   };
 
   useEffect(() => {
-    loadOrders();
     loadNotifications();
   }, [activeTab]);
 
@@ -168,18 +168,12 @@ const Admin = () => {
     knownOrderIds.current = new Set(orders.map(o => o.orderId));
   }, [orders]);
 
-  // Silent refresh of orders only (no loading state)
   useEffect(() => {
-    const interval = setInterval(async () => {
-      try {
-        const response = await getAdminOrders();
-        setOrders(response.orders);
-      } catch (error) {
-        console.error('Failed to refresh orders:', error);
-      }
-    }, 10000);
-
-    return () => clearInterval(interval);
+    const unsubscribe = subscribeToAdminOrders((newOrders) => {
+      setOrders(newOrders);
+      setIsLoading(false);
+    });
+    return () => unsubscribe();
   }, []);
 
   return (

--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -19,6 +19,7 @@ import {
 } from '@/services/orderService';
 import { toast } from '@/hooks/use-toast';
 import { NavigationSidebar } from '@/components/NavigationSidebar';
+import { NewOrderFlash, FlashOrder } from '@/components/NewOrderFlash';
 
 const Admin = () => {
   const [orders, setOrders] = useState<OrderDetails[]>([]);
@@ -27,6 +28,7 @@ const Admin = () => {
   const [activeTab, setActiveTab] = useState('all');
   const knownOrderIds = useRef<Set<string> | null>(null);
   const audioCtxRef = useRef<AudioContext | null>(null);
+  const [flashOrder, setFlashOrder] = useState<FlashOrder | null>(null);
 
   const ensureAudioCtx = () => {
     if (!audioCtxRef.current) {
@@ -164,6 +166,11 @@ const Admin = () => {
     const fresh = orders.filter(o => !knownOrderIds.current!.has(o.orderId));
     if (fresh.length > 0) {
       playNewOrderSound();
+      setFlashOrder({
+        orderId: fresh[0].orderId,
+        table: fresh[0].table,
+        total: fresh[0].total
+      });
     }
     knownOrderIds.current = new Set(orders.map(o => o.orderId));
   }, [orders]);
@@ -178,6 +185,7 @@ const Admin = () => {
 
   return (
     <div className="min-h-screen bg-turbo-dark text-turbo-text pb-20">
+      <NewOrderFlash order={flashOrder} onDismiss={() => setFlashOrder(null)} />
       <header className="flex items-center justify-between p-4 border-b border-border">
         <NavigationSidebar />
 

--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -160,24 +160,21 @@ const Admin = () => {
   }, [activeTab]);
 
   useEffect(() => {
-    if (knownOrderIds.current === null) {
-      knownOrderIds.current = new Set(orders.map(o => o.orderId));
-      return;
-    }
-    const fresh = orders.filter(o => !knownOrderIds.current!.has(o.orderId));
-    if (fresh.length > 0) {
-      playNewOrderSound();
-      setFlashOrder({
-        orderId: fresh[0].orderId,
-        table: fresh[0].table,
-        total: fresh[0].total
-      });
-    }
-    knownOrderIds.current = new Set(orders.map(o => o.orderId));
-  }, [orders]);
-
-  useEffect(() => {
     const unsubscribe = subscribeToAdminOrders((newOrders) => {
+      if (knownOrderIds.current === null) {
+        knownOrderIds.current = new Set(newOrders.map(o => o.orderId));
+      } else {
+        const fresh = newOrders.filter(o => !knownOrderIds.current!.has(o.orderId));
+        if (fresh.length > 0) {
+          playNewOrderSound();
+          setFlashOrder({
+            orderId: fresh[0].orderId,
+            table: fresh[0].table,
+            total: fresh[0].total
+          });
+        }
+        knownOrderIds.current = new Set(newOrders.map(o => o.orderId));
+      }
       setOrders(newOrders);
       setIsLoading(false);
     });

--- a/src/pages/Cart.tsx
+++ b/src/pages/Cart.tsx
@@ -1,3 +1,4 @@
+import { useRef, useState } from 'react';
 import { ArrowLeft, Minus, Plus, Trash2 } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { useCart } from '@/contexts/CartContext';
@@ -12,6 +13,8 @@ const Cart = () => {
   const navigate = useNavigate();
   const { state, removeItem, updateQuantity, clearCart } = useCart();
   const { addOrder } = useOrderTracking();
+  const isSubmittingRef = useRef(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
   const getTableHome = () => {
     const stored = localStorage.getItem('turbo-table') || '';
@@ -45,10 +48,14 @@ const Cart = () => {
   };
 
   const handleOrderSubmission = async () => {
+    if (isSubmittingRef.current) return;
+    isSubmittingRef.current = true;
+    setIsSubmitting(true);
+
     try {
       const customerId = `customer-${Math.random().toString(36).substr(2, 9)}`;
       const tableId = localStorage.getItem('turbo-table') || '';
-      
+
       const orderData = {
         items: state.items,
         total: state.total,
@@ -57,26 +64,35 @@ const Cart = () => {
           id: customerId
         }
       };
-      
+
       const result = await submitOrder(orderData);
-      
+
       // Add the order to tracking
       addOrder(result);
-      
+
       clearCart();
-      
+
       toast({
         title: "Order complete!",
         description: "Someone is actively reviewing it.",
         duration: 5000,
       });
-      
+
       setTimeout(() => {
         navigate(getTableHome());
       }, 2000);
-      
+
+      // Keep the button disabled for a short cooldown after success,
+      // in case the user re-opens the cart before the redirect above fires.
+      setTimeout(() => {
+        isSubmittingRef.current = false;
+        setIsSubmitting(false);
+      }, 3000);
+
     } catch (error) {
       console.error('Error submitting order:', error);
+      isSubmittingRef.current = false;
+      setIsSubmitting(false);
       toast({
         title: "Order submission failed",
         description: "Please try again or contact support.",
@@ -187,11 +203,12 @@ const Cart = () => {
                   <span className="text-2xl font-bold text-amber-400">{state.total} Lei</span>
                 </div>
                 <div className="space-y-2">
-                  <Button 
+                  <Button
                     className="w-full bg-primary hover:bg-primary/90 text-primary-foreground"
                     onClick={handleOrderSubmission}
+                    disabled={isSubmitting}
                   >
-                    Submit Order
+                    {isSubmitting ? 'Submitting...' : 'Submit Order'}
                   </Button>
                   <Button 
                     variant="outline" 
@@ -208,7 +225,11 @@ const Cart = () => {
       </div>
       {state.items.length > 0 && (
         <OrderFooter
-          primaryAction={{ label: 'Submit Order', onClick: handleOrderSubmission }}
+          primaryAction={{
+            label: isSubmitting ? 'Submitting...' : 'Submit Order',
+            onClick: handleOrderSubmission,
+            disabled: isSubmitting
+          }}
         />
       )}
     </div>

--- a/src/services/orderService.ts
+++ b/src/services/orderService.ts
@@ -1,12 +1,13 @@
 import { CartItem } from '@/contexts/CartContext';
-import { 
-  createOrderRecord, 
-  getOrderRecord, 
-  getOrdersByStatus, 
+import {
+  createOrderRecord,
+  getOrderRecord,
+  getOrdersByStatus,
   updateOrderRecord,
   createNotificationRecord,
   getUnreadNotifications,
-  getOrdersByDateRange
+  getOrdersByDateRange,
+  subscribeToOrders
 } from './firebaseService';
 
 export interface OrderDetails {
@@ -112,6 +113,24 @@ export const getAdminOrders = async (status?: string): Promise<{orders: OrderDet
     console.error('Error getting admin orders from Firebase:', error);
     throw error;
   }
+};
+
+export const subscribeToAdminOrders = (
+  callback: (orders: OrderDetails[]) => void
+): (() => void) => {
+  return subscribeToOrders((dbOrders) => {
+    const orders = dbOrders.map(order => ({
+      orderId: order.orderId,
+      items: order.items as CartItem[],
+      total: order.total,
+      table: order.table,
+      customerInfo: order.customerInfo,
+      status: order.status,
+      updatedAt: order.updatedAt,
+      createdAt: order.createdAt
+    }));
+    callback(orders);
+  });
 };
 
 export const getOrderStatus = async (orderId: string): Promise<OrderDetails> => {


### PR DESCRIPTION
## Summary
- Guard the Cart's "Submit Order" button against spam-clicking (ref+state guard, 3s cooldown on success, immediate reset on failure) to stop duplicate Firestore orders.
- Switch Admin from 10s Firestore polling to a real-time `onSnapshot` subscription (`subscribeToAdminOrders`), cutting new-order alert latency from up to 10s to ~1s.
- Add a full-screen pulsing `NewOrderFlash` alert on Admin alongside the existing new-order sound, auto-dismissing after ~4.5s without blocking clicks underneath.
- Fix a mount-time race where the new-order baseline was seeded from the initial empty state instead of the first real snapshot, which would have made the flash/sound fire on nearly every Admin page load.

Design doc: `docs/superpowers/specs/2026-07-03-order-rate-limit-and-alert-design.md`
Implementation plan: `docs/superpowers/plans/2026-07-03-order-rate-limit-and-alert.md`

## Test plan
- [ ] Rapid-click "Submit Order" in the cart with 1+ items; confirm only one order is created in Firestore and the button disables/relabels correctly.
- [ ] Open `/admin` and place an order from another tab; confirm the flash + sound fire within ~1s, show correct table/total, and auto-dismiss after ~4.5s without blocking clicks.
- [ ] Reload `/admin` with existing orders present; confirm the flash/sound do NOT fire on load.
- [ ] `npx tsc --noEmit` passes (no automated test suite exists in this repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)